### PR TITLE
Limit Qiita title length

### DIFF
--- a/python/article_generator.py
+++ b/python/article_generator.py
@@ -244,6 +244,9 @@ class ArticleGenerator:
         # タイトルが抽出できない場合はトピックから生成
         if not title:
             title = f"{topic}について"
+
+        # Qiitaのタイトル上限に合わせて50文字に切り詰め
+        title = title[:50]
         
         # タグが抽出できない場合はデフォルトタグを設定
         if not tags:

--- a/python/article_generator.py
+++ b/python/article_generator.py
@@ -13,6 +13,9 @@ from dotenv import load_dotenv
 # 環境変数を読み込み
 load_dotenv()
 
+# Qiitaのタイトル上限文字数
+QIITA_TITLE_MAX_LENGTH = 50
+
 @dataclass
 class ArticleData:
     """記事データの構造"""
@@ -245,8 +248,8 @@ class ArticleGenerator:
         if not title:
             title = f"{topic}について"
 
-        # Qiitaのタイトル上限に合わせて50文字に切り詰め
-        title = title[:50]
+        # Qiitaのタイトル上限に合わせて切り詰め
+        title = title[:QIITA_TITLE_MAX_LENGTH]
         
         # タグが抽出できない場合はデフォルトタグを設定
         if not tags:


### PR DESCRIPTION
## Summary
- crop generated article title to 50 characters before saving

## Testing
- `python -m py_compile python/article_generator.py generate_and_publish.py`
- `mix test` *(fails: Mix requires Hex package manager and internet access is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6873aa2d4fac8320b2e9f5c4871d5666